### PR TITLE
Fix installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ OR
 * clone this repo to your Packages directory
 
 * Install node, npm
-* `npm install -g js2coffee`
+* `npm install -g js2coffee coffee-script`
 * `cmd-shift-p` Package Control: Install Package -> JS2Coffee
 
 


### PR DESCRIPTION
coffee should be available as a global alias

Just installing js2coffee doesn't add alias for coffee-script. If someone doesn't have it, then an error appears: 

Traceback (most recent call last):
  File "./sublime_plugin.py", line 362, in run_
  File "./JS2Coffee.py", line 25, in run
  File "./JS2Coffee.py", line 61, in new_buffer
  File "./JS2Coffee.py", line 56, in js2coffee
OSError: /usr/bin/env: coffee: No such file or directory
